### PR TITLE
Remove ajv

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@types/node": "14.14.37",
     "@wildpeaks/eslint-config-commonjs": "11.2.0",
     "@wildpeaks/prettier-config": "11.2.0",
-    "ajv": "8.0.1",
     "css-loader": "5.2.0",
     "eslint": "7.23.0",
     "express": "4.17.1",


### PR DESCRIPTION
Forgot to remove it from dependencies when I restructure the package, used to be for testing the JSON Schema of the package, but it's redundant because if the JSON is malformed, tests would fail anyway.